### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "ext-mcrypt": "*",
-    "mdanter/ecc": "dev-master",
+    "mdanter/ecc": "0.2.0",
     "pleonasm/merkle-tree": "1.0.0",
     "fguillot/json-rpc": "0.0.1",
     "rych/hash_pbkdf2-compat": "~1.0",


### PR DESCRIPTION
installing with dev-master for the ecc package results in this error

    " bitwasp/bitcoin 0.0.2 requires mdanter/ecc dev-master -> no matching package found. "

updated this to use a specific package that works